### PR TITLE
fix: change "parse" api after upgrade

### DIFF
--- a/Markdown.js
+++ b/Markdown.js
@@ -32,7 +32,7 @@ sap.ui.define(["sap/ui/core/Control", "./marked/marked.min"], (Control /*, marke
                     return
                 }
                 if (sMarkdown) {
-                    const sHtml = marked(sMarkdown)
+                    const sHtml = marked.parse(sMarkdown)
                     oRM.unsafeHtml(sHtml)
                     oRM.close("div")
                 } else if (oControl.getFromFile()) {


### PR DESCRIPTION
breaking changes after upgrade from 2.0.0 --> 4.0.12
from `marked(content)` to `marked.parse(content)`
see https://github.com/markedjs/marked#usage